### PR TITLE
Restart mysqld upon changing the my.cnf file.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"

--- a/recipes/mysql_user.rb
+++ b/recipes/mysql_user.rb
@@ -5,6 +5,7 @@ template node[:tungsten][:mysqlConfigFile] do
   owner "root"
   group "root"
   action :create
+  notifies :reload, "service[mysqld]", :immediately
 end
 
 template "#{node[:tungsten][:rootHome]}/.my.cnf" do

--- a/recipes/prereq.rb
+++ b/recipes/prereq.rb
@@ -167,3 +167,8 @@ if node[:tungsten][:installSSHKeys] == true
 	end
 
 end
+
+# Define here so we can use it in any recipe we like
+service "mysqld" do
+  action :nothing
+end


### PR DESCRIPTION
If mysql is running already with the wrong settings, the my.cnf placement in the mysql_users recipe does not cause it to restart, causing tungsten to fail upon "tpm update".