### PR TITLE
Remove "path" from the execute resource.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.1"
+version          "0.1.2"

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -50,7 +50,6 @@ group "mysql" do
 end
 
 execute "tungsten_set_mysql_admin_password" do
-  path ["/bin", "/usr/bin"]
   command "mysqladmin -u#{node[:tungsten][:mysqlAdminUser]} password #{node[:tungsten][:mysqlAdminPassword]}"
   only_if	{ "/usr/bin/test -f /usr/bin/mysql" && "/usr/bin/mysql -u {node[:tungsten][:mysqlAdminUser]}" }
 end


### PR DESCRIPTION
Path was removed in chef v12 due to being unimplemented.