### PR TITLE
Escape shell parameters when using them on the command line.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.4"
+version          "0.1.5"
 
 depends "selinux", "~> 0.8.0"

--- a/recipes/mysql_user.rb
+++ b/recipes/mysql_user.rb
@@ -8,12 +8,22 @@ template "#{node[:tungsten][:rootHome]}/.my.cnf" do
   action :create
 end
 
+require 'shellwords'
 template "#{Chef::Config[:file_cache_path]}/tungsten_create_mysql_users.sh" do
   mode 00700
   source "tungsten_create_mysql_users.erb"
   owner "root"
   group "root"
   action :create
+  variables({
+    :escaped => {
+      'repUser' => Shellwords.escape(node['tungsten']['repUser']),
+      'repPassword' => Shellwords.escape(node['tungsten']['repPassword']),
+      'appUser' => Shellwords.escape(node['tungsten']['appUser']),
+      'appPassword' => Shellwords.escape(node['tungsten']['appPassword'])
+    },
+    :rootHome => Shellwords.escape(node['tungsten']['rootHome'])
+  })
   only_if { File.exists?("#{node[:tungsten][:rootHome]}/.my.cnf") }
 end
 

--- a/templates/default/tungsten_create_mysql_users.erb
+++ b/templates/default/tungsten_create_mysql_users.erb
@@ -19,15 +19,15 @@
 # limitations under the License.
 #
 
-replication_user=<%= node[:tungsten][:repUser] -%>
+replication_user='<%= @escaped['repUser'] -%>'
 
-replication_password=<%= node[:tungsten][:repPassword] -%>
+replication_password='<%= @escaped['repPassword'] -%>'
 
-application_user=<%= node[:tungsten][:appUser] -%>
+application_user='<%= @escaped['appUser'] -%>'
 
-application_password=<%= node[:tungsten][:appPassword]  -%>
+application_password='<%= @escaped['appPassword']  -%>'
 
-root_home=<%= node[:tungsten][:rootHome] -%>
+root_home='<%= @rootHome -%>'
 
 if [ -f $root_home/.my.cnf ]
 then


### PR DESCRIPTION
Fixes issue with special characters being interpreted by bash.