### PR TITLE
Fix quoted escaped passwords creating different passwords than intended.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.5"
+version          "0.1.6"
 
 depends "selinux", "~> 0.8.0"

--- a/templates/default/tungsten_create_mysql_users.erb
+++ b/templates/default/tungsten_create_mysql_users.erb
@@ -19,15 +19,15 @@
 # limitations under the License.
 #
 
-replication_user='<%= @escaped['repUser'] -%>'
+replication_user=<%= @escaped['repUser'] -%>
 
-replication_password='<%= @escaped['repPassword'] -%>'
+replication_password=<%= @escaped['repPassword'] -%>
 
-application_user='<%= @escaped['appUser'] -%>'
+application_user=<%= @escaped['appUser'] -%>
 
-application_password='<%= @escaped['appPassword']  -%>'
+application_password=<%= @escaped['appPassword']  -%>
 
-root_home='<%= @rootHome -%>'
+root_home=<%= @rootHome -%>
 
 if [ -f $root_home/.my.cnf ]
 then


### PR DESCRIPTION
Escaped passwords were being stored which led to differences with the other .ini files, causing failure.