### PR TITLE
Add Tungsten service script

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.6"
+version          "1.0.0"
 
 depends "selinux", "~> 0.8.0"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -1,0 +1,30 @@
+# === Copyright
+#
+# Copyright 2014 Continuent Inc.
+#
+# === License
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+template '/etc/init.d/tungsten' do
+  owner 'root'
+  mode 0755
+  source 'tungsten.init.d.erb'
+  variables({
+    :user => node['tungsten']['systemUser'],
+    :path => "#{node['tungsten']['homeDir']}/tungsten/cluster-home/bin"
+  })
+end
+
+execute 'chkconfig --add tungsten && chkconfig --level 2345 tungsten on'

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,0 +1,30 @@
+
+describe 'tungsten::service' do
+
+  let(:chef_run) {
+    ChefSpec::SoloRunner.new do |node|
+      node.set['tungsten']['systemUser'] = 'bob'
+      node.set['tungsten']['homeDir'] = '/home/bob'
+    end.converge(described_recipe)
+  }
+
+  it 'should create an init.d script' do
+    expect(chef_run).to create_template('/etc/init.d/tungsten').with({
+      owner: 'root',
+      mode: 0755
+    })
+  end
+
+  it 'should allow the init.d script to start tungsten' do
+    expect(chef_run).to render_file('/etc/init.d/tungsten').with_content(/start\(\) \{{\n|\s}*su - bob -c \/home\/bob\/tungsten\/cluster-home\/bin\/startall &/)
+  end
+
+  it 'should allow the init.d script to stop tungsten' do
+    expect(chef_run).to render_file('/etc/init.d/tungsten').with_content(/stop\(\) \{{\n|\s}*su - bob -c \/home\/bob\/tungsten\/cluster-home\/bin\/stopall &/)
+  end
+
+  it 'should enable the script' do
+    expect(chef_run).to run_execute('chkconfig --add tungsten && chkconfig --level 2345 tungsten on')
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+current_dir = File.dirname(__FILE__)
+
+RSpec.configure do |config|
+  # Point to the cookbooks directory
+  config.cookbook_path = File.join(current_dir, '../cookbooks')
+end

--- a/templates/default/tungsten.init.d.erb
+++ b/templates/default/tungsten.init.d.erb
@@ -1,0 +1,36 @@
+#!/bin/bash
+# chkconfig: 2345 20 80
+# description: Start or stop Tungsten services
+
+# Source function library.
+. /etc/init.d/functions
+
+start() {
+    su - <%= @user %> -c <%= @path %>/startall &
+}
+
+stop() {
+    su - <%= @user %> -c <%= @path %>/stopall &
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        stop
+        start
+        ;;
+    status)
+        # code to check status of app comes here
+        # example: status program_name
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|restart}"
+esac
+
+exit 0
+


### PR DESCRIPTION
This PR adds a recipe that sets up a tungsten service and allows it to start on boot. The recipe is not used by default.

The PR also bumps the cookbook version to 1.0.0. I think this makes sense from a semver point of view, because the cookbook is being used in real environments and so has technically been deployed.