### PR TITLE
Define the service as a service resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
-name             "tungsten"
-maintainer       "VMWare"
-license          "Apache"
-description      "Installs and manages Tungsten replicator, manager and connector"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.0"
+name              'tungsten'
+maintainer        'VMWare'
+license           'Apache'
+description       'Installs and manages Tungsten replicator, manager and connector'
+long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version           '1.1.0'
 
-depends "selinux", "~> 0.8.0"
+depends 'selinux', '~> 0.8.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer       "VMWare"
 license          "Apache"
 description      "Installs and manages Tungsten replicator, manager and connector"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.0.0"
+version          "1.1.0"
 
 depends "selinux", "~> 0.8.0"

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -28,3 +28,8 @@ template '/etc/init.d/tungsten' do
 end
 
 execute 'chkconfig --add tungsten && chkconfig --level 2345 tungsten on'
+
+service 'tungsten' do
+  action :nothing
+  supports :status => true, :start => true, :stop => true, :restart => true
+end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -27,4 +27,10 @@ describe 'tungsten::service' do
     expect(chef_run).to run_execute('chkconfig --add tungsten && chkconfig --level 2345 tungsten on')
   end
 
+  it 'should define a tungsten service resource' do
+    resource = chef_run.service('tungsten')
+    expect(resource).to do_nothing
+    expect(resource.supports).to eq({:status => true, :start => true, :stop => true, :restart => true})
+  end
+
 end


### PR DESCRIPTION
This defines the service added in 1.0.0 as a service resource for use elsewhere within Chef. metadata.rb is now bumped to 1.1.0 as this represents a non-breaking new feature.