### PR TITLE
Allow backup directory path to be configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,7 @@ default[:tungsten][:mysqljLocation] = '/opt/mysql/mysql-connector-java-5.1.26-bi
 default[:tungsten][:profileScript] = '~/.bash_profile'
 
 default[:tungsten][:homeDir] = '/opt/continuent'
+default[:tungsten][:backupDir] = '/opt/continuent/backups'
 default[:tungsten][:prereqDirectories] = [
 	"#{node[:tungsten][:homeDir]}",
 	"#{node[:tungsten][:homeDir]}/software",

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,6 @@ maintainer        'VMWare'
 license           'Apache'
 description       'Installs and manages Tungsten replicator, manager and connector'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.1.0'
+version           '1.2.0'
 
 depends 'selinux', '~> 0.8.0'

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -26,6 +26,14 @@ template "/etc/tungsten/tungsten.ini" do
 	source "tungsten_ini.erb"
 end
 
+directory node[:tungsten][:backupDir] do
+  owner node[:tungsten][:systemUser]
+  group node[:tungsten][:systemUser]
+  mode 0755
+  action :create
+  recursive true
+end
+
 remote_file "#{Chef::Config[:file_cache_path]}/#{node[:tungsten][:clusterSoftware]}" do
 	source "#{node[:tungsten][:clusterSoftwareSource]}#{node[:tungsten][:clusterSoftware]}"
 	owner node[:tungsten][:systemUser]

--- a/templates/default/tungsten_ini.erb
+++ b/templates/default/tungsten_ini.erb
@@ -37,6 +37,8 @@ application-user=<%= node[:tungsten][:appUser] -%>
 
 application-password=<%= node[:tungsten][:appPassword] -%>
 
+backup-directory=<%= node[:tungsten][:backupDir] -%>
+
 skip-validation-check=MySQLPermissionsCheck
 #skip-validation-check=ManagerWitnessNeededCheck
 start-and-report=true


### PR DESCRIPTION
This adds the `backup-directory` option to the tungsten.ini template, and gives it a default value of `/opt/continuent/backup` for BC. It also makes the cluster recipe create the backup directory if it does not exist.

Version bumped to 1.2.0.