### PR TITLE
Configure test kitchen + fix a few issues found with ubuntu

### DIFF
--- a/.Vagrantfile.cachier.rb
+++ b/.Vagrantfile.cachier.rb
@@ -1,0 +1,12 @@
+Vagrant.configure('2') do |config|
+  # Enable Vagrant Cachier, for speedy destroy/creates
+  if Vagrant.has_plugin?("vagrant-cachier")
+    # Configure cached packages to be shared between instances of the same base box.
+    # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+    config.cache.scope = :box
+
+    config.cache.enable :generic, {
+      :cache_dir => "/tmp/kitchen"
+    }
+  end
+end

--- a/.Vagrantfile.disable-berkshelf.rb
+++ b/.Vagrantfile.disable-berkshelf.rb
@@ -1,0 +1,5 @@
+Vagrant.configure('2') do |config|
+  if Vagrant.has_plugin?("vagrant-berkshelf") then
+    config.berkshelf.enabled = false
+  end
+end

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,19 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+    attributes:
+      tungsten:
+        prereqPackages:
+          - ruby
+          - wget
+          - rsync
   - name: ubuntu-14.04
+    attributes:
+      tungsten:
+        prereqPackages:
+          - ruby
+          - wget
+          - rsync
   - name: centos-6.5
     attributes:
       tungsten:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,9 @@
 ---
 driver:
   name: vagrant
+  vagrantfiles:
+    - .Vagrantfile.cachier.rb
+    - .Vagrantfile.disable-berkshelf.rb
 
 provisioner:
   name: chef_solo

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,7 @@ platforms:
     attributes:
       tungsten:
         prereqPackages:
-          - ruby
+          - ruby1.8-full
           - wget
           - rsync
   - name: ubuntu-14.04
@@ -36,10 +36,12 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[apt::default]
       - recipe[tungsten::server]
     attributes:
       tungsten:
         installMysqlServer: true
+        installJava: false
         repUser: tungsten
         repPassword: "test"
         appUser: app_user

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,14 +3,43 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_solo
+  require_chef_omnibus: 12.1.0
+  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: centos-6.5
+    attributes:
+      tungsten:
+        prereqPackages:
+          - ruby
+          - wget
+          - rsync
 
 suites:
   - name: default
     run_list:
-      - recipe[tungsten::default]
+      - recipe[tungsten::server]
     attributes:
+      tungsten:
+        installMysqlServer: true
+        repUser: tungsten
+        repPassword: "test"
+        appUser: app_user
+        appPassword: "test"
+        mysqlAdminUser: root
+        mysqlAdminPassword: "test"
+      mysql:
+        server_debian_password: "test"
+        server_root_password: "test"
+        server_repl_password: "test"
+        master: true
+        client:
+          packages:
+            - "mysql55-devel"
+            - "mysql55-libs"
+        server:
+          packages:
+            - "mysql55-server"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,6 +48,7 @@ suites:
         appPassword: "test"
         mysqlAdminUser: root
         mysqlAdminPassword: "test"
+        serviceName: "somerandomservice"
       mysql:
         server_debian_password: "test"
         server_root_password: "test"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,21 @@
+source "https://rubygems.org"
+
+gem 'berkshelf', '~> 3.2'
+
+group :chef_development do
+  # Automatically run Tests upon file change
+  gem 'guard', '~> 2.11.0'
+  gem 'guard-kitchen', :git => 'git://github.com/logankoester/guard-kitchen.git', :ref => 'af7a86afdc64d8d338d544993c84c5d4aef392df'
+  gem 'guard-foodcritic', :git => 'git://github.com/Nordstrom/guard-foodcritic.git', :branch => 'use_guard_v2_api'
+  gem 'guard-rspec', '~> 4.5.0'
+
+  gem 'chefspec'
+  gem 'test-kitchen', '~> 1.3.0'
+  gem 'kitchen-vagrant'
+  gem 'foodcritic'
+
+  # Windows notifications
+  gem 'rb-notifu'
+  # OSX notifications
+  gem 'terminal-notifier-guard'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :chef_development do
   gem 'guard-rspec', '~> 4.5.0'
 
   gem 'chefspec'
-  gem 'test-kitchen', '~> 1.3.0'
-  gem 'kitchen-vagrant'
+  gem 'test-kitchen', '~> 1.3.1'
+  gem 'kitchen-vagrant', :git => 'git://github.com/test-kitchen/kitchen-vagrant.git', :ref => '9f9b502fb7bcb461e8f805e01c2e87abc3077654'
   gem 'foodcritic'
 
   # Windows notifications

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 default['tungsten']['clusterSoftware'] = 'continuent-tungsten-2.0.5-3.noarch.rpm'
 default['tungsten']['clusterSoftwareSource'] = 'https://s3.amazonaws.com/releases.continuent.com/ct-2.0.4/'
-default['tungsten']['clusterSoftwareChecksum'] = 'b8ea78762f66a9c9b8ca7e884ae310083981f1fb'
+default['tungsten']['clusterSoftwareChecksum'] = '0cc17eb545c110be3045005c91e136e3205c6e75930bf54195348a69e96f4379'
 
 default['tungsten']['prereqPackages'] = [
 	'ruby18',

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,3 +6,4 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '1.2.0'
 
 depends 'selinux', '~> 0.8.0'
+depends 'apt'

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -46,8 +46,14 @@ template node['tungsten']['mysqlConfigFile'] do
   action :create
 end
 
+service_name = 'mysqld'
+if node.platform_family?('debian') then
+  service_name = 'mysql'
+end
+
 service "mysqld" do
-	action :start
+  service_name service_name
+  action :start
 end
 
 group "mysql" do


### PR DESCRIPTION
To test with test kitchen do the following:
   
    bundle install
    kitchen test

This gets you most of the way through installation before failing on tpm update with a lack of other data sources to talk to.
Hopefully there is no cluster named "somerandomservice" accessible from the machine or the VM that boots!

It also adds tools "foodcritic" and "chefspec", where some specs and foodcritic fixes have already been merged into this cookbook.

Again, no version bump or release necessary at the moment.