### PR TITLE
Use Community Packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -54,10 +54,3 @@ suites:
         server_root_password: "test"
         server_repl_password: "test"
         master: true
-        client:
-          packages:
-            - "mysql55-devel"
-            - "mysql55-libs"
-        server:
-          packages:
-            - "mysql55-server"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,6 +49,9 @@ suites:
         mysqlAdminUser: root
         mysqlAdminPassword: "test"
         serviceName: "somerandomservice"
+        master: "foo"
+        members: "foo,foo2,foo3"
+        connectors: "bar1,bar2,bar3"
       mysql:
         server_debian_password: "test"
         server_root_password: "test"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,13 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License.
 #
-include_attribute 'mysql'
+include_attribute 'mysql::server'
+include_attribute 'mysql::server_debian'
+include_attribute 'mysql::server_freebsd'
+include_attribute 'mysql::server_mac_os_x'
+include_attribute 'mysql::server_rhel'
+include_attribute 'mysql::server_suse'
+include_attribute 'mysql::server_windows'
 
 default['tungsten']['clusterSoftware'] = 'continuent-tungsten-2.0.5-3.noarch.rpm'
 default['tungsten']['clusterSoftwareSource'] = 'https://s3.amazonaws.com/releases.continuent.com/ct-2.0.4/'
@@ -82,7 +88,7 @@ default['tungsten']['mysqlBinlogFormat'] = 'ROW'
 default['tungsten']['mysqlIncrement'] = 10
 default['tungsten']['mysqlOffset'] = 1
 
-default['tungsten']['mysqlServiceName']        = node['mysql']['server']['service_name']
+default['tungsten']['mysqlServiceName']      = node['mysql']['server']['service_name']
 
 default['tungsten']['mysqlConfigDir']        = node['mysql']['server']['directories']['confd_dir']
 default['tungsten']['mysqlConfigFile']       = "#{default[:tungsten][:mysqlConfigDir]}/tungsten.cnf"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,7 +91,7 @@ default['tungsten']['mysqlOffset'] = 1
 default['tungsten']['mysqlServiceName']      = node['mysql']['server']['service_name']
 
 default['tungsten']['mysqlConfigDir']        = node['mysql']['server']['directories']['confd_dir']
-default['tungsten']['mysqlConfigFile']       = "#{default[:tungsten][:mysqlConfigDir]}/tungsten.cnf"
+default['tungsten']['mysqlConfigFile']       = "#{default['tungsten']['mysqlConfigDir']}/tungsten.cnf"
 
 default['tungsten']['mysqlDataDir']          = node['mysql']['data_dir']
 default['tungsten']['mysqlPIDFile']          = node['mysql']['server']['pid_file']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License.
 #
+include_attribute 'mysql'
 
 default['tungsten']['clusterSoftware'] = 'continuent-tungsten-2.0.5-3.noarch.rpm'
 default['tungsten']['clusterSoftwareSource'] = 'https://s3.amazonaws.com/releases.continuent.com/ct-2.0.4/'
@@ -28,8 +29,7 @@ default['tungsten']['prereqPackages'] = [
 	'ruby18-devel',
 	'wget',
 	'sudo',
-	'rsync',
-	'mysql'
+	'rsync'
 ]
 
 default['tungsten']['clusterSoftwareDir'] = default['tungsten']['clusterSoftware'].gsub( /\.noarch\.rpm/, '' )
@@ -61,6 +61,7 @@ default['tungsten']['appUser'] = 'app_user'
 default['tungsten']['appPassword'] = 'secret'
 
 default['tungsten']['repPort'] = '13306'
+default['mysql']['port'] = node['tungsten']['repPort']
 default['tungsten']['repUser'] = 'tungsten'
 default['tungsten']['repPassword'] = 'secret'
 
@@ -69,8 +70,8 @@ default['tungsten']['master'] = 'db1'
 default['tungsten']['members'] = 'db1'
 default['tungsten']['connectors'] = 'db1'
 
-default['tungsten']['mysqlAdminUser'] = 'root'
-default['tungsten']['mysqlAdminPassword'] = 'secret'
+default['tungsten']['mysqlAdminUser'] = node['mysql']['server_root_user']
+default['tungsten']['mysqlAdminPassword'] = node['mysql']['server_root_password']
 
 default['tungsten']['rootHome'] = File.expand_path('~root')
 
@@ -81,34 +82,14 @@ default['tungsten']['mysqlBinlogFormat'] = 'ROW'
 default['tungsten']['mysqlIncrement'] = 10
 default['tungsten']['mysqlOffset'] = 1
 
-if node['platform'] =~ /(?i:centos|redhat|oel|amazon)/
-        default['tungsten']['mysqlServiceName']        = 'mysqld'
+default['tungsten']['mysqlServiceName']        = node['mysql']['server']['service_name']
 
-        default['tungsten']['mysqlConfigDir']          = '/etc'
-        default['tungsten']['mysqlConfigFile']         = "#{default['tungsten']['mysqlConfigDir']}/my.cnf"
+default['tungsten']['mysqlConfigDir']        = node['mysql']['server']['directories']['confd_dir']
+default['tungsten']['mysqlConfigFile']       = "#{default[:tungsten][:mysqlConfigDir]}/tungsten.cnf"
 
-        default['tungsten']['mysqlDataDir']            = '/var/lib/mysql'
-        default['tungsten']['mysqlPIDFile']            = '/var/lib/mysql/mysqld.pid'
-        default['tungsten']['mysqlSocket']             = '/var/lib/mysql/mysql.sock'
-
-        #default['tungsten']['serverPackageName']      = 'Percona-Server-server-55'
-        #default['tungsten']['clientPackageName']      = 'Percona-Server-client-55'
-
-elsif node['platform'] =~ /(?i:debian|ubuntu)/
-        default['tungsten']['mysqlServiceName']        = 'mysql'
-        
-        default['tungsten']['mysqlConfigDir']          = '/etc/mysql'
-        default['tungsten']['mysqlConfigFile']         = "#{default['tungsten']['mysqlConfigDir']}/my.cnf"
-
-        default['tungsten']['mysqlDataDir']            = '/var/lib/mysql'
-        default['tungsten']['mysqlPIDFile']            = '/var/run/mysqld/mysqld.pid'
-        default['tungsten']['mysqlSocket']             = '/var/run/mysqld/mysqld.sock'
-
-        #default['tungsten']['serverPackageName']      = 'Percona-Server-server-5.5'
-        #default['tungsten']['clientPackageName']      = 'Percona-Server-client-5.5'
-else
-	default['tungsten']['installMysqlServer'] = false
-end
+default['tungsten']['mysqlDataDir']          = node['mysql']['data_dir']
+default['tungsten']['mysqlPIDFile']          = node['mysql']['server']['pid_file']
+default['tungsten']['mysqlSocket']           = node['mysql']['server']['socket']
 
 default['tungsten']['sshPublicKey_custom'] = nil
 default['tungsten']['sshPublicKey'] = 'AAAAB3NzaC1yc2EAAAABIwAAAQEAo3LUB/ZA1VCzHKqcZ/bFS0Hh1QyRASYblsRbxAhLlu4mWKsnzOPlbcgCs2mvEcP6K1OFd6VRm5PhjDgclzeQOTl582Ugnzt9Kz6FU9ea5tzkCob+5nEAJnvpbHmm7ZRsQzc5UYq9O5EonQCno7BXHuUcBkb9ZoVXl1oiuaJmDEKM2ynFwoItd0kpclcRQg9LcE3gSOWfwXRxxYrsccLERih3rqYU6PnyQH6cqdU2VgJeVmaRSfK82cEsRTBrUc17hbI5Nii3JiVr33TYXssYxVDkB8TSe3zaEkVvJoKbdWbhRVa4BWDupk3xAyEPaXAOt3eE0pjMpw2KjpBIl8H/Fw=='
@@ -148,6 +129,6 @@ else
 	default['tungsten']['installNTP']	= true
 end
 
-include_attribute "java"
+include_attribute 'java'
 default['java']['install_flavour'] = 'openjdk'
 default['java']['jdk_version'] = '7'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -147,3 +147,7 @@ if node['platform'] == 'amazon'
 else
 	default['tungsten']['installNTP']	= true
 end
+
+include_attribute "java"
+default['java']['install_flavour'] = 'openjdk'
+default['java']['jdk_version'] = '7'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,5 +7,5 @@ version           '1.2.0'
 
 depends 'selinux', '~> 0.8.0'
 depends 'apt'
-depends 'mysql'
+depends 'mysql', '~> 4.1.2'
 depends 'java'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'VMWare'
 license           'Apache'
 description       'Installs and manages Tungsten replicator, manager and connector'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.2.0'
+version           '2.0.0'
 
 depends 'selinux', '~> 0.8.0'
 depends 'apt'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,5 @@ version           '1.2.0'
 
 depends 'selinux', '~> 0.8.0'
 depends 'apt'
+depends 'mysql'
+depends 'java'

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -32,7 +32,7 @@ template node['tungsten']['mysqlConfigFile'] do
   owner "root"
   group "root"
   action :create
-  notifies 'service[mysql]', :restart
+  notifies :restart, 'service[mysql]'
 end
 
 group "mysql" do

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -16,12 +16,11 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License.
 #
-unless node['platform'] =~ /(?i:centos|redhat|oel|amazon|debian|ubuntu)/
-	fail "The mysql_server recipe is not supported on an #{node['platform']}-based system."
-end
 
-package "mysql-server" do
-	action :install
+include_recipe "mysql::server"
+
+unless node['platform'] =~ /(?i:centos|redhat|oel|amazon|debian|ubuntu)/
+  fail "The mysql_server recipe is not supported on an #{node['platform']}-based system."
 end
 
 directory "/etc/mysql" do

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -19,18 +19,7 @@
 
 include_recipe "mysql::server"
 
-unless node['platform'] =~ /(?i:centos|redhat|oel|amazon|debian|ubuntu)/
-  fail "The mysql_server recipe is not supported on an #{node['platform']}-based system."
-end
-
-directory "/etc/mysql" do
-  owner "root"
-  group "root"
-  mode 00755
-  action :create
-end
-
-directory "/etc/mysql/conf.d" do
+directory node['tungsten']['mysqlConfigDir'] do
   owner "root"
   group "root"
   mode 00755
@@ -43,25 +32,11 @@ template node['tungsten']['mysqlConfigFile'] do
   owner "root"
   group "root"
   action :create
-end
-
-service_name = 'mysqld'
-if node.platform_family?('debian') then
-  service_name = 'mysql'
-end
-
-service "mysqld" do
-  service_name service_name
-  action :start
+  notifies 'service[mysql]', :restart
 end
 
 group "mysql" do
 	action :manage
 	append true
 	members node['tungsten']['systemUser']
-end
-
-execute "tungsten_set_mysql_admin_password" do
-  command "mysqladmin -u#{node['tungsten']['mysqlAdminUser']} password #{node['tungsten']['mysqlAdminPassword']}"
-  only_if	{ "/usr/bin/test -f /usr/bin/mysql" && "/usr/bin/mysql -u {node['tungsten']['mysqlAdminUser']}" }
 end

--- a/recipes/prereq.rb
+++ b/recipes/prereq.rb
@@ -45,14 +45,7 @@ node['tungsten']['prereqPackages'].each do |pkg|
 end
 
 if node['tungsten']['installJava'] == true
-	package "java" do
-		action :install
-		not_if { node['platform'] == "amazon" }
-	end
-	package "java-1.7.0-openjdk" do
-		action :install
-		only_if { node['platform'] == "amazon" }
-	end
+  include_recipe "java"
 end
 
 group node['tungsten']['systemUser'] do

--- a/recipes/prereq.rb
+++ b/recipes/prereq.rb
@@ -157,8 +157,3 @@ if node['tungsten']['installSSHKeys'] == true
 	end
 
 end
-
-# Define here so we can use it in any recipe we like
-service "mysqld" do
-  action :nothing
-end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -2,7 +2,7 @@
 describe 'tungsten::service' do
 
   let(:chef_run) {
-    ChefSpec::SoloRunner.new do |node|
+    ChefSpec::SoloRunner.new(platform: 'centos', version: '6.5') do |node|
       node.set['tungsten']['systemUser'] = 'bob'
       node.set['tungsten']['homeDir'] = '/home/bob'
     end.converge(described_recipe)


### PR DESCRIPTION
Here's the biggest change so far.

Use the community mysql and java cookbooks to do most of the legwork for us in regards to platform differences and package installations, allowing this cookbook to focus upon tungsten.

This will probably need some extra testing and does require a new release - I bumped the version to 2.0.0 to reflect the change of approach.