### PR TITLE
Allow configurable backup retention

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,8 @@ default['tungsten']['mysqlOffset'] = 1
 
 default['tungsten']['mysqlServiceName']      = node['mysql']['server']['service_name']
 
+default['tungsten']['backupRetention'] = 3
+
 default['tungsten']['mysqlConfigDir']        = node['mysql']['server']['directories']['confd_dir']
 default['tungsten']['mysqlConfigFile']       = "#{default['tungsten']['mysqlConfigDir']}/tungsten.cnf"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'VMWare'
 license           'Apache'
 description       'Installs and manages Tungsten replicator, manager and connector'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.0.0'
+version           '2.1.0'
 
 depends 'selinux', '~> 0.8.0'
 depends 'apt'

--- a/templates/default/tungsten_ini.erb
+++ b/templates/default/tungsten_ini.erb
@@ -39,6 +39,8 @@ application-password=<%= node['tungsten']['appPassword'] -%>
 
 backup-directory=<%= node['tungsten']['backupDir'] -%>
 
+backup-retention=<%= node['tungsten']['backupRetention'] -%>
+
 skip-validation-check=MySQLPermissionsCheck
 #skip-validation-check=ManagerWitnessNeededCheck
 start-and-report=true


### PR DESCRIPTION
Allows the backup retention setting to be configured within tungsten.ini.

Bumps version to 2.1.0.