### PR TITLE
[WIP] Allow connection keepalive to be configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,6 +92,9 @@ default['tungsten']['mysqlServiceName']      = node['mysql']['server']['service_
 
 default['tungsten']['backupRetention'] = 3
 
+default['tungsten']['connection']['keepAlive']['interval'] = 'autodetect'
+default['tungsten']['connection']['keepAlive']['timeout'] = 'autodetect'
+
 default['tungsten']['mysqlConfigDir']        = node['mysql']['server']['directories']['confd_dir']
 default['tungsten']['mysqlConfigFile']       = "#{default['tungsten']['mysqlConfigDir']}/tungsten.cnf"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'VMWare'
 license           'Apache'
 description       'Installs and manages Tungsten replicator, manager and connector'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.1.0'
+version           '2.2.0'
 
 depends 'selinux', '~> 0.8.0'
 depends 'apt'

--- a/templates/default/tungsten_ini.erb
+++ b/templates/default/tungsten_ini.erb
@@ -41,6 +41,9 @@ backup-directory=<%= node['tungsten']['backupDir'] -%>
 
 backup-retention=<%= node['tungsten']['backupRetention'] -%>
 
+connection.keepAlive.interval = <%= node['tungsten']['connection']['keepAlive']['interval'] -%>
+connection.keepAlive.timeout = <%= node['tungsten']['connection']['keepAlive']['timeout'] -%>
+
 skip-validation-check=MySQLPermissionsCheck
 #skip-validation-check=ManagerWitnessNeededCheck
 start-and-report=true


### PR DESCRIPTION
This PR allows the connector keep alive settings to be configured. It also bumps the cookbook version to 2.2.0.
